### PR TITLE
Properly flag when completely failed

### DIFF
--- a/src/helpers/checks.ts
+++ b/src/helpers/checks.ts
@@ -13,7 +13,7 @@ export function getChecksItemStatus(checksItem?: MonitorDailyChecksItem) {
       const checksTotalCount = Object.values(checksItem.stats).reduce((previous, current) => {
         return previous + current.count
       }, 0)
-      if (checksItem.fails === checksTotalCount) {
+      if (!Object.values(checksItem.stats).length || checksItem.fails === checksTotalCount) {
         status = 'all-incidents'
       } else {
         status = 'has-incident'


### PR DESCRIPTION
When there are no successful runs, the data will read `stats: {}`. This extra check shows red in that scenario.

Fixes #35.